### PR TITLE
feat: default command

### DIFF
--- a/lua/colortils/init.lua
+++ b/lua/colortils/init.lua
@@ -141,7 +141,7 @@ local commands = {
 --- Executes command
 ---@param args table
 local function exec_command(args)
-    commands[args.fargs[1]](args)
+    commands[args.fargs[1] or "picker"](args)
 end
 
 --- Creates the `Colortils` command


### PR DESCRIPTION
If `:Colortils` has no argument, `picker` is used by default instead of printing a cryptic error message.