### PR TITLE
feat(init): add default_color option to colortils setup

### DIFF
--- a/lua/colortils/init.lua
+++ b/lua/colortils/init.lua
@@ -6,6 +6,8 @@ colortils.settings = {
     color_preview = "█ %s",
     ---String: "hex"|"rgb"|"hsl"
     default_format = "hex",
+    ---String: default color if no color is found
+    default_color = "#000000",
     border = "rounded",
     background = "#FFFFFF",
     mappings = {
@@ -47,7 +49,7 @@ local function get_color(color, invalid)
         return color_table
     end
     if invalid then
-        color = vim.fn.input("Input a valid color > ", "")
+        return get_color(colortils.settings.default_color, false)
     else
         color = vim.fn.input("Input a color > ", "")
     end

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ require("colortils").setup({
         -- save the current color in the register specified above with the format specified above
         set_register_default_format = "<cr>",
         -- save the current color in the register specified above with a format you can choose
-        set_register_cjoose_format = "g<cr>",
+        set_register_choose_format = "g<cr>",
         -- replace the color under the cursor with the current color in the format specified above
         replace_default_format = "<m-cr>",
         -- replace the color under the cursor with the current color in a format you can choose

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ require("colortils").setup({
     -- The default in which colors should be saved
     -- This can be hex, hsl or rgb
     default_format = "hex",
+    -- String: default color if no color is found
+    default_color = "#000000",
     -- Border for the float
     border = "rounded",
     -- Some mappings which are used inside the tools


### PR DESCRIPTION
This pull request adds the `default_color` option to the `colortils` setup in both the `readme.md` file and `colortils/init.lua`.

The `default_color` option allows users to set a default color value when no color is found. This enhancement provides more flexibility and customization to the `colortils` plugin.
                                                                                                                                                                                                                                                          
#### Use Cases:
```lua
-- Setting default_color to a specific color
require("colortils").setup({
    default_color = "#FF0000",
    -- Other settings
})
```

BTW, correct a typo in the README.md

Feel free to review and test this enhancement. Thank you!
