### PR TITLE
Fix: blocks instead of gradient in neovim 11

### DIFF
--- a/lua/colortils/css.lua
+++ b/lua/colortils/css.lua
@@ -209,7 +209,7 @@ function css.list_colors()
         border = require("colortils").settings.border,
         style = "minimal",
     })
-    vim.api.nvim__set_option_value("modifiable", false, {buf = buf})
+    vim.api.nvim__set_option_value("modifiable", false, { buf = buf })
     -- try to attach colorizer
     pcall(vim.cmd, "ColorizerAttachToBuffer")
 end

--- a/lua/colortils/css.lua
+++ b/lua/colortils/css.lua
@@ -209,7 +209,7 @@ function css.list_colors()
         border = require("colortils").settings.border,
         style = "minimal",
     })
-    vim.api.nvim_buf_set_option(buf, "modifiable", false)
+    vim.api.nvim__set_option_value("modifiable", false, {buf = buf})
     -- try to attach colorizer
     pcall(vim.cmd, "ColorizerAttachToBuffer")
 end

--- a/lua/colortils/init.lua
+++ b/lua/colortils/init.lua
@@ -25,7 +25,7 @@ colortils.settings = {
         set_value = "c",
         transparency = "T",
         choose_background = "B",
-        quit_window = { "q", "<esc>" }
+        quit_window = { "q", "<esc>" },
     },
 }
 

--- a/lua/colortils/tools/gradients/init.lua
+++ b/lua/colortils/tools/gradients/init.lua
@@ -37,7 +37,7 @@ local format_strings = {
 }
 
 local function update(colors, state)
-    vim.api.nvim_set_option_value("modifiable", true, {buf = state.buf})
+    vim.api.nvim_set_option_value("modifiable", true, { buf = state.buf })
     vim.api.nvim_buf_set_lines(state.buf, 0, 1, false, {})
     color_utils.display_gradient(
         state.buf,
@@ -79,7 +79,7 @@ local function update(colors, state)
             bg = settings.background,
         })
     end
-    vim.api.nvim_set_option_value("modifiable", false, {buf = state.buf})
+    vim.api.nvim_set_option_value("modifiable", false, { buf = state.buf })
     vim.api.nvim_buf_add_highlight(
         state.buf,
         state.ns,
@@ -157,7 +157,7 @@ return function(color, color_2, alpha)
         border = settings.border,
     })
     vim.api.nvim_win_set_hl_ns(state.win, state.ns)
-    vim.api.nvim_set_option_value("cursorline", false, {win = state.win})
+    vim.api.nvim_set_option_value("cursorline", false, { win = state.win })
     color_utils.display_gradient(
         state.buf,
         state.ns,
@@ -168,14 +168,14 @@ return function(color, color_2, alpha)
         colors.alpha,
         colortils.settings.background
     )
-    if next(vim.api.nvim_get_hl(0, {name = "NormalFloat"})) == nil then
+    if next(vim.api.nvim_get_hl(0, { name = "NormalFloat" })) == nil then
         vim.api.nvim_set_hl(0, "NormalFloat", { link = "Normal" })
     end
-    local cursor_fg = vim.api.nvim_get_hl(0, {name="Cursor"}).fg
-    local cursor_bg = vim.api.nvim_get_hl(0, {name="Cursor"}).bg
+    local cursor_fg = vim.api.nvim_get_hl(0, { name = "Cursor" }).fg
+    local cursor_bg = vim.api.nvim_get_hl(0, { name = "Cursor" }).bg
     vim.api.nvim_set_hl(0, "Cursor", {
-        fg = vim.api.nvim_get_hl(0, {name = "NormalFloat"}).bg,
-        bg = vim.api.nvim_get_hl(0, {name = "NormalFloat"}).bg,
+        fg = vim.api.nvim_get_hl(0, { name = "NormalFloat" }).bg,
+        bg = vim.api.nvim_get_hl(0, { name = "NormalFloat" }).bg,
     })
     vim.opt_local.guicursor = "a:ver1-Cursor/Cursor"
 
@@ -370,7 +370,7 @@ return function(color, color_2, alpha)
         end
         help_state.open = true
         help_state.buf = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_set_option_value("bufhidden", "wipe", {buf = help_state.buf})
+        vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = help_state.buf })
         local lines = {
             "Keybindings",
             "Increment:                                     " .. colortils.settings.mappings.increment,
@@ -421,7 +421,7 @@ return function(color, color_2, alpha)
                 help_state.buf = nil
             end,
         })
-        vim.api.nvim_set_option_value("modifiable", false, {buf = help_state.buf})
+        vim.api.nvim_set_option_value("modifiable", false, { buf = help_state.buf })
     end, {
         buffer = state.buf,
     })

--- a/lua/colortils/tools/gradients/init.lua
+++ b/lua/colortils/tools/gradients/init.lua
@@ -99,7 +99,7 @@ local function adjust(amount, state)
     end
     if row == 2 then
         state.idx = state.idx + amount
-        state.idx = math.max(math.min(state.idx, 255), 0)
+        state.idx = math.max(math.min(state.idx, 255), 1)
     else
         state.transparency = math.max(math.min(state.transparency + amount, 100), 0)
     end

--- a/lua/colortils/tools/gradients/init.lua
+++ b/lua/colortils/tools/gradients/init.lua
@@ -37,7 +37,7 @@ local format_strings = {
 }
 
 local function update(colors, state)
-    vim.api.nvim_buf_set_option(state.buf, "modifiable", true)
+    vim.api.nvim_set_option_value("modifiable", true, {buf = state.buf})
     vim.api.nvim_buf_set_lines(state.buf, 0, 1, false, {})
     color_utils.display_gradient(
         state.buf,
@@ -79,7 +79,7 @@ local function update(colors, state)
             bg = settings.background,
         })
     end
-    vim.api.nvim_buf_set_option(state.buf, "modifiable", false)
+    vim.api.nvim_set_option_value("modifiable", false, {buf = state.buf})
     vim.api.nvim_buf_add_highlight(
         state.buf,
         state.ns,
@@ -156,7 +156,8 @@ return function(color, color_2, alpha)
         height = 3,
         border = settings.border,
     })
-    vim.api.nvim_win_set_option(state.win, "cursorline", false)
+    vim.api.nvim_win_set_hl_ns(state.win, state.ns)
+    vim.api.nvim_set_option_value("cursorline", false, {win = state.win})
     color_utils.display_gradient(
         state.buf,
         state.ns,
@@ -167,14 +168,14 @@ return function(color, color_2, alpha)
         colors.alpha,
         colortils.settings.background
     )
-    if vim.api.nvim_exec("hi NormalFloat", true):match("NormalFloat%s*xxx%s*cleared") then
+    if next(vim.api.nvim_get_hl(0, {name = "NormalFloat"})) == nil then
         vim.api.nvim_set_hl(0, "NormalFloat", { link = "Normal" })
     end
-    local cursor_fg = vim.api.nvim_get_hl_by_name("Cursor", true).foreground
-    local cursor_bg = vim.api.nvim_get_hl_by_name("Cursor", true).background
+    local cursor_fg = vim.api.nvim_get_hl(0, {name="Cursor"}).fg
+    local cursor_bg = vim.api.nvim_get_hl(0, {name="Cursor"}).bg
     vim.api.nvim_set_hl(0, "Cursor", {
-        fg = vim.api.nvim_get_hl_by_name("NormalFloat", true).background,
-        bg = vim.api.nvim_get_hl_by_name("NormalFloat", true).background,
+        fg = vim.api.nvim_get_hl(0, {name = "NormalFloat"}).bg,
+        bg = vim.api.nvim_get_hl(0, {name = "NormalFloat"}).bg,
     })
     vim.opt_local.guicursor = "a:ver1-Cursor/Cursor"
 
@@ -369,7 +370,7 @@ return function(color, color_2, alpha)
         end
         help_state.open = true
         help_state.buf = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_option(help_state.buf, "bufhidden", "wipe")
+        vim.api.nvim_set_option_value("bufhidden", "wipe", {buf = help_state.buf})
         local lines = {
             "Keybindings",
             "Increment:                                     " .. colortils.settings.mappings.increment,
@@ -420,7 +421,7 @@ return function(color, color_2, alpha)
                 help_state.buf = nil
             end,
         })
-        vim.api.nvim_buf_set_option(help_state.buf, "modifiable", false)
+        vim.api.nvim_set_option_value("modifiable", false, {buf = help_state.buf})
     end, {
         buffer = state.buf,
     })

--- a/lua/colortils/tools/gradients/init.lua
+++ b/lua/colortils/tools/gradients/init.lua
@@ -157,7 +157,6 @@ return function(color, color_2, alpha)
         border = settings.border,
     })
     vim.api.nvim_win_set_hl_ns(state.win, state.ns)
-    vim.api.nvim_set_option_value("cursorline", false, { win = state.win })
     color_utils.display_gradient(
         state.buf,
         state.ns,
@@ -176,6 +175,7 @@ return function(color, color_2, alpha)
     vim.api.nvim_set_hl(0, "Cursor", {
         fg = vim.api.nvim_get_hl(0, { name = "NormalFloat" }).bg,
         bg = vim.api.nvim_get_hl(0, { name = "NormalFloat" }).bg,
+        blend = 100,
     })
     vim.opt_local.guicursor = "a:ver1-Cursor/Cursor"
 
@@ -187,7 +187,7 @@ return function(color, color_2, alpha)
                 vim.opt_local.guicursor = "a:ver1-Cursor/Cursor"
             else
                 vim.opt.guicursor = old_cursor
-                vim.api.nvim_set_hl(0, "Cursor", { fg = cursor_fg, bg = cursor_bg })
+                vim.api.nvim_set_hl(0, "Cursor", { fg = cursor_fg, bg = cursor_bg, blend = 0 })
             end
         end,
     })

--- a/lua/colortils/utils/colors.lua
+++ b/lua/colortils/utils/colors.lua
@@ -91,18 +91,18 @@ utils_color.display_gradient =
         for i = 1, width do
             vim.api.nvim_set_hl(ns, "ColortilsGradient" .. i, { fg = gradient[2 * i], bg = gradient[2 * i + 1] })
         end
-        for i = 1, (width / 2)  do
-          virt_text[i] = {padding, "ColortilsGradient" .. i}
+        for i = 1, (width / 2) do
+            virt_text[i] = { padding, "ColortilsGradient" .. i }
         end
         vim.api.nvim_buf_set_lines(buf, line, line, false, { string.rep(" ", width / 2) })
         vim.api.nvim_buf_set_extmark(buf, ns, line, 0, {
-          end_col = width,
-          priority = 0,
-          virt_text = virt_text,
-          virt_text_pos = "overlay",
-          strict = false
+            end_col = width,
+            priority = 0,
+            virt_text = virt_text,
+            virt_text_pos = "overlay",
+            strict = false,
         })
-      end
+    end
 
 --- Gets the gray color for a certain color
 ---@param color string "#xxxxxx"

--- a/lua/colortils/utils/colors.lua
+++ b/lua/colortils/utils/colors.lua
@@ -61,6 +61,8 @@ function utils_color.get_blended_gradient(start_color, end_color, length, alpha,
     return blended_gradient
 end
 
+local padding = "▌"
+
 utils_color.display_gradient =
     --- Displays gradient at a certain position
     ---@param buf number
@@ -84,14 +86,23 @@ utils_color.display_gradient =
         else
             gradient = utils_color.gradient_colors(start_color, end_color, width)
         end
-        vim.api.nvim_buf_set_lines(buf, line, line, false, { string.rep("▌", width / 2) })
+
+        local virt_text = {}
         for i = 1, width do
-            vim.api.nvim_set_hl(0, "ColortilsGradient" .. i, { fg = gradient[2 * i], bg = gradient[2 * i + 1] })
+            vim.api.nvim_set_hl(ns, "ColortilsGradient" .. i, { fg = gradient[2 * i], bg = gradient[2 * i + 1] })
         end
-        for i = 1, width do
-            vim.api.nvim_buf_add_highlight(buf, ns, "ColortilsGradient" .. i, line, 3 * i - 1, 3 * i)
+        for i = 1, (width / 2)  do
+          virt_text[i] = {padding, "ColortilsGradient" .. i}
         end
-    end
+        vim.api.nvim_buf_set_lines(buf, line, line, false, { string.rep(" ", width / 2) })
+        vim.api.nvim_buf_set_extmark(buf, ns, line, 0, {
+          end_col = width,
+          priority = 0,
+          virt_text = virt_text,
+          virt_text_pos = "overlay",
+          strict = false
+        })
+      end
 
 --- Gets the gray color for a certain color
 ---@param color string "#xxxxxx"

--- a/lua/colortils/utils/colors.lua
+++ b/lua/colortils/utils/colors.lua
@@ -96,11 +96,10 @@ utils_color.display_gradient =
         end
         vim.api.nvim_buf_set_lines(buf, line, line, false, { string.rep(" ", width / 2) })
         vim.api.nvim_buf_set_extmark(buf, ns, line, 0, {
-            end_col = width,
-            priority = 0,
+            end_col = (width / 2) - 1,
             virt_text = virt_text,
             virt_text_pos = "overlay",
-            strict = false,
+            hl_eol = false,
         })
     end
 

--- a/makefile
+++ b/makefile
@@ -1,3 +1,6 @@
+lint:
+	stylua lua/
+
 test:
 	nvim --headless --noplugin \
 	-u tests/custom_init.vim \


### PR DESCRIPTION
* Fixes #31 
* Fixes a fencepost error that would display `nil` in gradient pickers when scrolling the marker past the left bound
* Updates some miscellaneous deprecations
* Adds a make target for running `stylua`

I was having the same issue as #31 using neovim v0.11.0-nightly with alacritty 0.14.0.

By switching to using extmarks directly with virtual text, the gradient renders correctly.  This also allows setting the highlight group for each character individually.

Also fixes a small fencepost bug where `adjust(-1, state)` could return nil by seeking out of range.